### PR TITLE
fix: stop recording on modal close

### DIFF
--- a/src/components/AudioManager.tsx
+++ b/src/components/AudioManager.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import axios from "axios";
 import Modal from "./modal/Modal";
 import { UrlInput } from "./modal/UrlInput";
@@ -32,6 +32,7 @@ export function AudioManager({ transcriber, onTranscriptionComplete }: Props) {
     const [audioDownloadUrl, setAudioDownloadUrl] = useState<string | undefined>(undefined);
     const [showUrlModal, setShowUrlModal] = useState(false);
     const [showRecordModal, setShowRecordModal] = useState(false);
+    const stopRecordingRef = useRef<() => void>(null);
 
     const isAudioLoading = progress !== undefined;
 
@@ -368,9 +369,12 @@ export function AudioManager({ transcriber, onTranscriptionComplete }: Props) {
                 show={showRecordModal}
                 title="Record Audio"
                 content={
-                    <AudioRecorder onRecordingComplete={setAudioFromRecording} />
+                    <AudioRecorder onRecordingComplete={setAudioFromRecording} stopRecordingRef={stopRecordingRef} />
                 }
-                onClose={() => setShowRecordModal(false)}
+                onClose={() => {
+                    stopRecordingRef.current?.()
+                    setShowRecordModal(false)
+                }}
                 onSubmit={() => {}}
             />
         </div>

--- a/src/components/AudioRecorder.tsx
+++ b/src/components/AudioRecorder.tsx
@@ -1,16 +1,18 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useImperativeHandle } from 'react';
 import { LiveAudioVisualizer } from 'react-audio-visualize';
 
 interface Props {
   onRecordingComplete: (blob: Blob) => void;
+  stopRecordingRef: React.RefObject<() => void>
 }
 
-const AudioRecorder: React.FC<Props> = ({ onRecordingComplete }) => {
+const AudioRecorder: React.FC<Props> = ({ onRecordingComplete, stopRecordingRef }) => {
   const [isRecording, setIsRecording] = useState(false);
   const [recordingTime, setRecordingTime] = useState(0);
   const [mediaRecorder, setMediaRecorder] = useState<MediaRecorder | null>(null);
   const timeInterval = useRef<number | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  useImperativeHandle(stopRecordingRef, () => stopRecording);
 
   const startRecording = async () => {
     try {
@@ -41,7 +43,6 @@ const AudioRecorder: React.FC<Props> = ({ onRecordingComplete }) => {
 
   const stopRecording = () => {
     if (mediaRecorder && isRecording) {
-      mediaRecorder.stop();
       if (streamRef.current) {
         streamRef.current.getTracks().forEach(track => track.stop());
       }


### PR DESCRIPTION
Fixes #5 issue.

- stop recording on when modal is closed.
- fix audio context closing error, as react-audio-visualize is already handling the closing of the audio context.