### PR TITLE
Use different models for summarization

### DIFF
--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -2,10 +2,10 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Editor } from '@tinymce/tinymce-react';
 import { IoCopyOutline } from 'react-icons/io5';
 import { AiOutlineRobot } from 'react-icons/ai';
-import Transcript from "./Transcript";
+import Transcript from './Transcript';
+import TextSummary from './TextSummary';
 import { Transcriber } from "../hooks/useTranscriber";
 import { useSummarizer } from '../hooks/useSummarizer';
-import { TextSummary } from './TextSummary';
 
 interface NoteVersion {
   content: string;

--- a/src/components/TextSummary.tsx
+++ b/src/components/TextSummary.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { IoClose, IoSettingsSharp } from 'react-icons/io5';
 import Progress from './Progress';
+// ninja focus touch <
+import { summarizationModels, SummarizationModel } from '../hooks/useSummarizer';
+// ninja focus touch >
 
 interface TextSummaryProps {
   summary: string | null;
@@ -8,8 +11,8 @@ interface TextSummaryProps {
   progress: { status: string; progress?: number } | null;
   onClose: () => void;
   // ninja focus touch <
-  model: 't5-small' | 't5-base';
-  onModelChange: (model: 't5-small' | 't5-base') => void;
+  model: SummarizationModel;
+  onModelChange: (model: SummarizationModel) => void;
   // ninja focus touch >
 }
 
@@ -53,11 +56,12 @@ export default function TextSummary({
           {/* ninja focus touch < */}
           <select
             value={model}
-            onChange={(e) => onModelChange(e.target.value as 't5-small' | 't5-base')}
+            onChange={(e) => onModelChange(e.target.value as SummarizationModel)}
             className="block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
           >
-            <option value="t5-small">t5-small (faster)</option>
-            <option value="t5-base">t5-base (better quality)</option>
+            {summarizationModels.map(model => (
+              <option key={model} value={model}>{model}</option>
+            ))}
           </select>
           {/* ninja focus touch > */}
         </div>

--- a/src/components/TextSummary.tsx
+++ b/src/components/TextSummary.tsx
@@ -7,8 +7,10 @@ interface TextSummaryProps {
   isLoading: boolean;
   progress: { status: string; progress?: number } | null;
   onClose: () => void;
+  // ninja focus touch <
   model: 't5-small' | 't5-base';
   onModelChange: (model: 't5-small' | 't5-base') => void;
+  // ninja focus touch >
 }
 
 export const TextSummary: React.FC<TextSummaryProps> = ({
@@ -48,6 +50,7 @@ export const TextSummary: React.FC<TextSummaryProps> = ({
           <label className="block text-sm font-medium text-gray-700 mb-2">
             Model Selection
           </label>
+          {/* ninja focus touch < */}
           <select
             value={model}
             onChange={(e) => onModelChange(e.target.value as 't5-small' | 't5-base')}
@@ -56,6 +59,7 @@ export const TextSummary: React.FC<TextSummaryProps> = ({
             <option value="t5-small">t5-small (faster)</option>
             <option value="t5-base">t5-base (better quality)</option>
           </select>
+          {/* ninja focus touch > */}
         </div>
       )}
 

--- a/src/components/TextSummary.tsx
+++ b/src/components/TextSummary.tsx
@@ -13,14 +13,14 @@ interface TextSummaryProps {
   // ninja focus touch >
 }
 
-export const TextSummary: React.FC<TextSummaryProps> = ({
+export default function TextSummary({
   summary,
   isLoading,
   progress,
   onClose,
   model,
   onModelChange,
-}) => {
+}: TextSummaryProps) {
   const [showSettings, setShowSettings] = React.useState(false);
 
   if (!isLoading && !summary) return null;

--- a/src/components/TextSummary.tsx
+++ b/src/components/TextSummary.tsx
@@ -1,19 +1,15 @@
 import React from 'react';
 import { IoClose, IoSettingsSharp } from 'react-icons/io5';
 import Progress from './Progress';
-// ninja focus touch <
 import { summarizationModels, SummarizationModel } from '../hooks/useSummarizer';
-// ninja focus touch >
 
 interface TextSummaryProps {
   summary: string | null;
   isLoading: boolean;
   progress: { status: string; progress?: number } | null;
   onClose: () => void;
-  // ninja focus touch <
   model: SummarizationModel;
   onModelChange: (model: SummarizationModel) => void;
-  // ninja focus touch >
 }
 
 export default function TextSummary({
@@ -53,7 +49,6 @@ export default function TextSummary({
           <label className="block text-sm font-medium text-gray-700 mb-2">
             Model Selection
           </label>
-          {/* ninja focus touch < */}
           <select
             value={model}
             onChange={(e) => onModelChange(e.target.value as SummarizationModel)}
@@ -63,7 +58,6 @@ export default function TextSummary({
               <option key={model} value={model}>{model}</option>
             ))}
           </select>
-          {/* ninja focus touch > */}
         </div>
       )}
 

--- a/src/hooks/useSummarizer.ts
+++ b/src/hooks/useSummarizer.ts
@@ -2,14 +2,15 @@ import { useState, useCallback } from 'react';
 import { pipeline } from '@xenova/transformers';
 
 // ninja focus touch <
-type ModelType = 't5-small' | 't5-base';
+export const summarizationModels = ['t5-small', 't5-base'] as const;
+export type SummarizationModel = typeof summarizationModels[number];
 // ninja focus touch >
 
 export const useSummarizer = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = useState<{ status: string; progress?: number } | null>(null);
   // ninja focus touch <
-  const [model, setModel] = useState<ModelType>('t5-small');
+  const [model, setModel] = useState<SummarizationModel>(summarizationModels[0]);
   // ninja focus touch >
   const [summary, setSummary] = useState<string | null>(null);
 
@@ -43,7 +44,7 @@ export const useSummarizer = () => {
     setSummary(null);
   }, []);
 
-  const changeModel = useCallback((newModel: ModelType) => {
+  const changeModel = useCallback((newModel: SummarizationModel) => {
     setModel(newModel);
   }, []);
 

--- a/src/hooks/useSummarizer.ts
+++ b/src/hooks/useSummarizer.ts
@@ -1,17 +1,13 @@
 import { useState, useCallback } from 'react';
 import { pipeline } from '@xenova/transformers';
 
-// ninja focus touch <
-export const summarizationModels = ['t5-small', 't5-base'] as const;
+export const summarizationModels = ['t5-small', 't5-base', 'distilbart-cnn-6-6', 'bart-large-cnn'] as const;
 export type SummarizationModel = typeof summarizationModels[number];
-// ninja focus touch >
 
 export const useSummarizer = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = useState<{ status: string; progress?: number } | null>(null);
-  // ninja focus touch <
   const [model, setModel] = useState<SummarizationModel>(summarizationModels[0]);
-  // ninja focus touch >
   const [summary, setSummary] = useState<string | null>(null);
 
   const summarize = useCallback(async (text: string) => {

--- a/src/hooks/useSummarizer.ts
+++ b/src/hooks/useSummarizer.ts
@@ -1,12 +1,16 @@
 import { useState, useCallback } from 'react';
 import { pipeline } from '@xenova/transformers';
 
+// ninja focus touch <
 type ModelType = 't5-small' | 't5-base';
+// ninja focus touch >
 
 export const useSummarizer = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = useState<{ status: string; progress?: number } | null>(null);
+  // ninja focus touch <
   const [model, setModel] = useState<ModelType>('t5-small');
+  // ninja focus touch >
   const [summary, setSummary] = useState<string | null>(null);
 
   const summarize = useCallback(async (text: string) => {


### PR DESCRIPTION
@addyosmani
This change makes the summarization model usage configurable instead of hard-coded. The goal is to allow selecting different summarization models without changing code, simplifying experimentation and future model swaps.
![video](https://github.com/user-attachments/assets/80baa2c7-900b-4382-bd9d-1bc34716f9b1)